### PR TITLE
Update the API Docs link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-NE6GEV5L6H"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
 
     gtag('config', 'G-NE6GEV5L6H');
@@ -34,6 +35,7 @@
   <title>DataJoint.org</title>
   <link rel="stylesheet" href="./static/style.css" />
 </head>
+
 <body>
   <nav>
     <div class="nav-content-container">
@@ -50,13 +52,15 @@
     <div class="left-container">
       <div class="datajoint-explained">
         <h2 class="sub-heading">What is DataJoint?</h2>
-        <p class="default-text">DataJoint is an open-source framework for programming scientific databases with computational workflows. 
+        <p class="default-text">DataJoint is an open-source framework for programming scientific databases with
+          computational workflows.
           <br />
           <br />
           It provides consistent methods for organizing, populating, computing, and querying data.
           <br />
           <br />
-          DataJoint is for pipeline management based on relational principles.</p>
+          DataJoint is for pipeline management based on relational principles.
+        </p>
       </div>
     </div>
     <div class="right-container">
@@ -89,7 +93,8 @@
             </a>
           </li>
           <li class="starter-list-item">
-            <a class="external-link" href="https://docs-api.datajoint.org" target="_blank">
+            <a class="external-link"
+              href="https://datajoint.com/docs/core/datajoint-python/latest/api/datajoint/__init__/" target="_blank">
               <img src="./static/icons/doc-icons.svg" class="starter-icon" aria-hidden="true">
               <span class="default-text">API Documentation</span>
             </a>
@@ -97,8 +102,10 @@
           <li class="starter-list-item">
             <a class="external-link" href="https://tutorials.datajoint.org" target="_blank">
               <img src="./static/icons/tutorial-icon.svg" class="starter-icon" aria-hidden="true">
-              <div><span class="default-text">Tutorial</span><p class="small-text">* DataJoint CodeBook is the recommended 
-                method to start learning DataJoint.</p></div>
+              <div><span class="default-text">Tutorial</span>
+                <p class="small-text">* DataJoint CodeBook is the recommended
+                  method to start learning DataJoint.</p>
+              </div>
             </a>
           </li>
         </ul>
@@ -116,12 +123,16 @@
           </div>
           <div class="grid-cell">
             <p class="default-text grid-title"><b>DataJoint CodeBook</b></p>
-            <p class="default-text"><a class="highlight" href="https://codebook.datajoint.io/" target="_blank">DataJoint CodeBook</a> is an online <a class="highlight" href="https://jupyter.org">Jupyter</a>-based tutorial environment for DataJoint.
+            <p class="default-text"><a class="highlight" href="https://codebook.datajoint.io/" target="_blank">DataJoint
+                CodeBook</a> is an online <a class="highlight" href="https://jupyter.org">Jupyter</a>-based tutorial
+              environment for DataJoint.
             </p>
           </div>
           <div class="grid-cell">
             <p class="default-text grid-title"><b>Account Management</b></p>
-            <p class="default-text"><a class="highlight" href="https://accounts.datajoint.io/settings">DataJoint Accounts</a> is a free Single Sign-On experience for all commercially hosted applications and services. There you may manage your account and personal data.
+            <p class="default-text"><a class="highlight" href="https://accounts.datajoint.io/settings">DataJoint
+                Accounts</a> is a free Single Sign-On experience for all commercially hosted applications and services.
+              There you may manage your account and personal data.
             </p>
           </div>
         </div>
@@ -131,31 +142,34 @@
   <section class="os-projects-section">
     <div class="container">
       <div class="oss-card">
-        <img class="oss-logo" src="./static/images/elements-logo.png"/>
+        <img class="oss-logo" src="./static/images/elements-logo.png" />
         <div>
           <p class="default-text">Curated computational work&shy;flows for neuro&shy;physiology experi&shy;ments.</p>
           <a class="link-to-doc" href="https://elements.datajoint.org/" target="_blank"><button>Learn More</button></a>
         </div>
       </div>
       <div class="oss-card">
-        <img class="oss-logo" src="./static/images/labbook-logo.svg"/>
+        <img class="oss-logo" src="./static/images/labbook-logo.svg" />
         <div>
           <p class="default-text">Open-source data viewer and manage&shy;ment GUI that is DataJoint principle aware.</p>
-          <a class="link-to-doc" href="https://datajoint.github.io/datajoint-labbook/" target="_blank"><button>Learn More</button></a>
+          <a class="link-to-doc" href="https://datajoint.github.io/datajoint-labbook/" target="_blank"><button>Learn
+              More</button></a>
         </div>
       </div>
       <div class="oss-card">
-        <img class="oss-logo"  src="./static/images/pharus-logo.png"/>
+        <img class="oss-logo" src="./static/images/pharus-logo.png" />
         <div>
           <p class="default-text">Generic REST API server back&shy;end for DataJoint pipe&shy;lines.</p>
-          <a class="link-to-doc" href="https://datajoint.github.io/pharus/" target="_blank"><button>Learn More</button></a>
+          <a class="link-to-doc" href="https://datajoint.github.io/pharus/" target="_blank"><button>Learn
+              More</button></a>
         </div>
       </div>
       <div class="oss-card">
-        <img class="oss-logo"  src="./static/images/server-config.png"/>
+        <img class="oss-logo" src="./static/images/server-config.png" />
         <div>
           <p class="default-text">Docker image for mysql con&shy;figured to work with DataJoint.</p>
-          <a class="link-to-doc" href="https://github.com/datajoint/mysql-docker" target="_blank"><button>Learn More</button></a>
+          <a class="link-to-doc" href="https://github.com/datajoint/mysql-docker" target="_blank"><button>Learn
+              More</button></a>
         </div>
       </div>
     </div>
@@ -167,46 +181,67 @@
         <div class="question-card">
           <div class="default-text question">General <b>how-to</b> or <b>error</b> questions?</div>
           <div class="default-text answer">
-            <p>Visit <a class="highlight-muted" href="https://stackoverflow.com/questions/tagged/datajoint" target="_blank">Stack Overflow</a> datajoint tag</p>
+            <p>Visit <a class="highlight-muted" href="https://stackoverflow.com/questions/tagged/datajoint"
+                target="_blank">Stack Overflow</a> datajoint tag</p>
           </div>
         </div>
         <div class="question-card">
           <div class="default-text question">Participate in <b>open-ended discussions</b>?</div>
           <div class="default-text answer">
-            <p>Join DataJoint's <a href="https://join.slack.com/t/datajoint/shared_invite/zt-3pioa7mu-R_G_z07arbgLelDuDxotdg" class="highlight-muted" target="_blank">Slack community</a> or register for <a href="https://docs.google.com/forms/d/e/1FAIpQLSeMhZtzQQWB47I8HfPcJ5_pFyMhZO284PLIblDfshe30dEuXw/viewform?usp=sf_link" class="highlight-muted" target="_blank">Office Hours</a></p>
+            <p>Join DataJoint's <a
+                href="https://join.slack.com/t/datajoint/shared_invite/zt-3pioa7mu-R_G_z07arbgLelDuDxotdg"
+                class="highlight-muted" target="_blank">Slack community</a> or register for <a
+                href="https://docs.google.com/forms/d/e/1FAIpQLSeMhZtzQQWB47I8HfPcJ5_pFyMhZO284PLIblDfshe30dEuXw/viewform?usp=sf_link"
+                class="highlight-muted" target="_blank">Office Hours</a></p>
           </div>
         </div>
         <div class="question-card">
           <div class="default-text question">Interested in contributing?</div>
           <div class="default-text answer">
-            <p>Visit our <a href="https://docs.datajoint.org/python/community/02-Contribute.html" target="_blank" class="highlight-muted">contribution guideline</a></p>
+            <p>Visit our <a href="https://docs.datajoint.org/python/community/02-Contribute.html" target="_blank"
+                class="highlight-muted">contribution guideline</a></p>
           </div>
         </div>
         <div class="question-card">
           <div class="default-text question"><b>Bug</b> reports or <b>new feature requests?</b></div>
           <div class="default-text answer">
-            <p>Visit <a href="https://github.com/datajoint" target="_blank" class="highlight-muted">GitHub</a> issue tracker</p>
+            <p>Visit <a href="https://github.com/datajoint" target="_blank" class="highlight-muted">GitHub</a> issue
+              tracker</p>
             <ul>
-              <li><a href="https://github.com/datajoint/datajoint-python/issues" target="_blank"><img src="./static/icons/python-icon.svg" class="q-icon python" aria-hidden="true"><span>DataJoint Python</span></li></a>
-              <li><a href="https://github.com/datajoint/datajoint-matlab/issues" target="_blank"><img src="./static/icons/matlab-icon.svg" class="q-icon matlab" aria-hidden="true"><span>DataJoint MATLAB</span></li></a>
-              <li><a href="https://github.com/datajoint/datajoint-docs/issues" target="_blank"><img src="./static/icons/doc-icons.svg" class="q-icon docs" aria-hidden="true"><span>DataJoint Docs</span></li></a>
+              <li><a href="https://github.com/datajoint/datajoint-python/issues" target="_blank"><img
+                    src="./static/icons/python-icon.svg" class="q-icon python" aria-hidden="true"><span>DataJoint
+                    Python</span></li></a>
+              <li><a href="https://github.com/datajoint/datajoint-matlab/issues" target="_blank"><img
+                    src="./static/icons/matlab-icon.svg" class="q-icon matlab" aria-hidden="true"><span>DataJoint
+                    MATLAB</span></li></a>
+              <li><a href="https://github.com/datajoint/datajoint-docs/issues" target="_blank"><img
+                    src="./static/icons/doc-icons.svg" class="q-icon docs" aria-hidden="true"><span>DataJoint
+                    Docs</span></li></a>
             </ul>
           </div>
         </div>
         <div class="question-card">
           <div class="default-text question">Need pipeline setup assistance?</div>
           <div class="default-text answer">
-            <p>Visit <a href="https://datajoint.com/" target="_blank" class="highlight-muted">DataJoint.com</a> for available services</p>
+            <p>Visit <a href="https://datajoint.com/" target="_blank" class="highlight-muted">DataJoint.com</a> for
+              available services</p>
           </div>
         </div>
         <div class="question-card">
           <div class="default-text question">Interested in <b>feature roadmap</b>?</div>
           <div class="default-text answer">
-            <p>Visit <a href="https://github.com/orgs/datajoint/projects" target="_blank" class="highlight-muted">GitHub</a> milestone</p>
+            <p>Visit <a href="https://github.com/orgs/datajoint/projects" target="_blank"
+                class="highlight-muted">GitHub</a> milestone</p>
             <ul>
-              <li><a href="https://github.com/datajoint/datajoint-python/milestones" target="_blank"><img src="./static/icons/python-icon.svg" class="q-icon python" aria-hidden="true"><span>DataJoint Python</span></li></a>
-              <li><a href="https://github.com/datajoint/datajoint-matlab/milestones" target="_blank"><img src="./static/icons/matlab-icon.svg" class="q-icon matlab" aria-hidden="true"><span>DataJoint MATLAB</span></li></a>
-              <li><a href="https://github.com/datajoint/datajoint-docs/milestones" target="_blank"><img src="./static/icons/doc-icons.svg" class="q-icon docs" aria-hidden="true"><span>DataJoint Docs</span></li></a>
+              <li><a href="https://github.com/datajoint/datajoint-python/milestones" target="_blank"><img
+                    src="./static/icons/python-icon.svg" class="q-icon python" aria-hidden="true"><span>DataJoint
+                    Python</span></li></a>
+              <li><a href="https://github.com/datajoint/datajoint-matlab/milestones" target="_blank"><img
+                    src="./static/icons/matlab-icon.svg" class="q-icon matlab" aria-hidden="true"><span>DataJoint
+                    MATLAB</span></li></a>
+              <li><a href="https://github.com/datajoint/datajoint-docs/milestones" target="_blank"><img
+                    src="./static/icons/doc-icons.svg" class="q-icon docs" aria-hidden="true"><span>DataJoint
+                    Docs</span></li></a>
             </ul>
           </div>
         </div>
@@ -228,7 +263,8 @@
                 </a>
               </li>
               <li class="sponsored-list-item">
-                <a class="external-link" href="https://www.youtube.com/channel/UCdeCuFOTCXlVMRzh6Wk-lGg" target="_blank">
+                <a class="external-link" href="https://www.youtube.com/channel/UCdeCuFOTCXlVMRzh6Wk-lGg"
+                  target="_blank">
                   <img src="./static/icons/ytube-icon-white-sq.svg" class="sponsor-icon" aria-hidden="true">
                   <span>Youtube</span>
                 </a>
@@ -246,8 +282,10 @@
           <p class="footer-heading">DataJoint Commercial Services</p>
           <ul>
             <li class="footer-item footer-text"><a href="https://datajoint.com/" target="_blank">DataJoint.com</a></li>
-            <li class="footer-item footer-text"><a href="https://codebook.datajoint.io/" target="_blank">DataJoint CodeBook</a></li>
-            <li class="footer-item footer-text"><a href="https://accounts.datajoint.io/" target="_blank">Account Management</a></li>
+            <li class="footer-item footer-text"><a href="https://codebook.datajoint.io/" target="_blank">DataJoint
+                CodeBook</a></li>
+            <li class="footer-item footer-text"><a href="https://accounts.datajoint.io/" target="_blank">Account
+                Management</a></li>
           </ul>
         </div>
         <div class="footer-column">
@@ -255,7 +293,8 @@
           <ul>
             <li class="footer-item footer-text"><a href="./resources/">Full list of resources</a></li>
             <li class="footer-item footer-text"><a href="./logo-variations/">Logo guideline</a></li>
-            <li class="footer-item footer-text"><a href="https://github.com/datajoint" target="_blank">DataJoint Github organization</a></li>
+            <li class="footer-item footer-text"><a href="https://github.com/datajoint" target="_blank">DataJoint Github
+                organization</a></li>
           </ul>
         </div>
       </div>
@@ -263,4 +302,5 @@
     <div class="footer-note footer-text">All rights reserved &nbsp; DataJoint™ &nbsp; 2017-2022</div>
   </footer>
 </body>
+
 </html>


### PR DESCRIPTION
Formatter took over on this one but the only line I changed was the new site link. :sweat_smile: 

It is on this [line](https://github.com/datajoint/datajoint.org/pull/22/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051R97).